### PR TITLE
feat(rag): Add OpenAI LLM provider (sync)

### DIFF
--- a/backend/core/llm/openai.py
+++ b/backend/core/llm/openai.py
@@ -1,0 +1,39 @@
+from typing import Optional
+from openai import OpenAI
+
+from config import settings
+from core.llm.base import LLMProvider
+
+
+class OpenAILLMProvider(LLMProvider):
+    """
+    Synchronous OpenAI LLM provider.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        temperature: float = 0.2,
+        client: Optional[OpenAI] = None,
+    ):
+        if not settings.OPENAI_API_KEY:
+            raise ValueError("OPENAI_API_KEY is required for OpenAI LLM provider")
+
+        self.model = model
+        self.temperature = temperature
+        self.client = client or OpenAI(api_key=settings.OPENAI_API_KEY)
+
+    def generate(self, prompt: str) -> str:
+        if not prompt:
+            return ""
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            temperature=self.temperature,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt},
+            ],
+        )
+
+        return response.choices[0].message.content.strip()

--- a/backend/tests/test_llm_openai.py
+++ b/backend/tests/test_llm_openai.py
@@ -1,0 +1,54 @@
+import pytest
+from core.llm.openai import OpenAILLMProvider, settings
+
+
+class FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class FakeChoice:
+    def __init__(self, content):
+        self.message = FakeMessage(content)
+
+
+class FakeResponse:
+    def __init__(self, content):
+        self.choices = [FakeChoice(content)]
+
+
+class FakeChatCompletions:
+    @staticmethod
+    def create(model, temperature, messages):
+        return FakeResponse("hello from fake llm")
+
+
+class FakeOpenAIClient:
+    def __init__(self):
+        self.chat = type(
+            "chat",
+            (),
+            {"completions": FakeChatCompletions()},
+        )
+
+
+def test_generate_text(monkeypatch):
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", "test-key")
+
+    llm = OpenAILLMProvider(client=FakeOpenAIClient())
+    output = llm.generate("Hello")
+
+    assert output == "hello from fake llm"
+
+
+def test_empty_prompt(monkeypatch):
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", "test-key")
+
+    llm = OpenAILLMProvider(client=FakeOpenAIClient())
+    assert llm.generate("") == ""
+
+def test_empty_api_key(monkeypatch):
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", None)
+
+    with pytest.raises(ValueError):
+        OpenAILLMProvider()


### PR DESCRIPTION
Adds a synchronous OpenAI-based LLMProvider implementation
with a mockable design and unit tests. This will be used
by the core RAG pipeline in v0.2.
